### PR TITLE
Upgrade Ubuntu image of Github Actions

### DIFF
--- a/.github/workflows/secretlint.yaml
+++ b/.github/workflows/secretlint.yaml
@@ -1,1 +1,1 @@
-runs-on: ubuntu-18.04
+runs-on: ubuntu-22.04.04


### PR DESCRIPTION
closes https://github.com/haodc123/TFlashGame/issues/15 \nUpgrade Ubuntu runner image of Github Actions from ubuntu-18 to ubuntu-22.04